### PR TITLE
docs: Seed Nodes -> Persistent Peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo contains genesis files of all historical chains of the Panacea Mainnet
 
 These 3 public nodes below are operated by MediBloc with [PEX](https://docs.tendermint.com/master/spec/p2p/messages/pex.html) enabled.
 
-You can add them to the `persistent_peers` in your `config.toml`. For more details please see the [Tendermint document](https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#peers).
+You can add them to the `persistent_peers` in your `config.toml`. For more details, please see the [Tendermint document](https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#peers).
 
 ```
 e93f5df69cc1b9bda230b3efcf162d4672293ded@3.35.82.40:26656

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo contains genesis files of all historical chains of the Panacea Mainnet
 
 ## Persistent Peers
 
-These 3 public nodes below are operated by MediBloc with [PEX](https://docs.tendermint.com/master/spec/p2p/messages/pex.html) enabled.
+These public nodes below are operated by MediBloc with [PEX](https://docs.tendermint.com/master/spec/p2p/messages/pex.html) enabled.
 
 You can add them to the `persistent_peers` in your `config.toml`. For more details, please see the [Tendermint document](https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#peers).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This repo contains genesis files of all historical chains of the Panacea Mainnet
 - Genesis file: https://github.com/medibloc/panacea-mainnet/raw/master/panacea-3/genesis.json.gz
 
 
-## Seed Nodes
+## Persistent Peers
+
+These 3 public nodes below are operated by MediBloc with [PEX](https://docs.tendermint.com/master/spec/p2p/messages/pex.html) enabled.
+
+You can add them to the `persistent_peers` in your `config.toml`. For more details please see the [Tendermint document](https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#peers).
 
 ```
 e93f5df69cc1b9bda230b3efcf162d4672293ded@3.35.82.40:26656
@@ -18,8 +22,8 @@ e93f5df69cc1b9bda230b3efcf162d4672293ded@3.35.82.40:26656
 a83232db3a40e486b54b1463a43431e8490b808b@52.79.108.35:26656
 ```
 
-**These 3 seed nodes below will be deprecated soon.**
-If you are using these seed nodes, please change them to the new seed nodes above.
+**These 3 nodes below will be deprecated soon.**
+If you connect to these nodes, please change them to the new nodes above.
 ```
 8c41cc8a6fc59f05138ae6c16a9eec05d601ef71@13.209.177.91:26656
 cc0285c4d9cec8489f8bfed0a749dd8636406a0d@54.180.169.37:26656
@@ -31,6 +35,7 @@ cc0285c4d9cec8489f8bfed0a749dd8636406a0d@54.180.169.37:26656
 
 See the [Join the Network](https://medibloc.gitbook.io/panacea-core/guide/join-the-network) guide.
 
+
 ## Public Endpoints
 
 Several public endpoints are provided by MediBloc.
@@ -39,6 +44,7 @@ Several public endpoints are provided by MediBloc.
 - Cosmos REST: https://api.gopanacea.org
 - Cosmos gRPC: https://grpc.gopanacea.org
 - Tendermint RPC: https://rpc.gopanacea.org
+
 
 ## Explorer
 


### PR DESCRIPTION
As our duplex nodes are not `seed_mode = true`, it would be much clearer to call them `Persistent Peers` instead of `Seed Nodes`. 
